### PR TITLE
Preserving digests by using dir transport 

### DIFF
--- a/pkg/additional/collector.go
+++ b/pkg/additional/collector.go
@@ -23,6 +23,10 @@ const (
 	dockerProtocol          string = "docker://"
 	ociProtocol             string = "oci://"
 	ociProtocolTrimmed      string = "oci:"
+	dirProtocol             string = "dir://"
+	dirProtocolTrimmed      string = "dir:"
+	fileProtocol            string = "file://"
+	fileProtocolTrimmed     string = "file:"
 	additionalImagesDir     string = "additional-images"
 	blobsDir                string = "/blobs/sha256/"
 	diskToMirror            string = "diskToMirror"
@@ -72,7 +76,12 @@ func (o *Collector) AdditionalImagesCollector(ctx context.Context) ([]v1alpha3.C
 					return []v1alpha3.CopyImageSchema{}, nil
 				}
 				src := dockerProtocol + img.Name
-				dest := ociProtocolTrimmed + cacheDir
+				transport := strings.Split(o.Opts.Destination, "://")[0] + ":"
+				// copy only handles dir: or docker: not file:
+				if transport == fileProtocolTrimmed {
+					transport = dirProtocolTrimmed
+				}
+				dest := transport + cacheDir
 				o.Log.Debug("source %s", src)
 				o.Log.Debug("destination %s", dest)
 				allImages = append(allImages, v1alpha3.CopyImageSchema{Source: src, Destination: dest})

--- a/pkg/additional/collector.go
+++ b/pkg/additional/collector.go
@@ -25,8 +25,6 @@ const (
 	ociProtocolTrimmed      string = "oci:"
 	dirProtocol             string = "dir://"
 	dirProtocolTrimmed      string = "dir:"
-	fileProtocol            string = "file://"
-	fileProtocolTrimmed     string = "file:"
 	additionalImagesDir     string = "additional-images"
 	blobsDir                string = "/blobs/sha256/"
 	diskToMirror            string = "diskToMirror"
@@ -77,10 +75,6 @@ func (o *Collector) AdditionalImagesCollector(ctx context.Context) ([]v1alpha3.C
 				}
 				src := dockerProtocol + img.Name
 				transport := strings.Split(o.Opts.Destination, "://")[0] + ":"
-				// copy only handles dir: or docker: not file:
-				if transport == fileProtocolTrimmed {
-					transport = dirProtocolTrimmed
-				}
 				dest := transport + cacheDir
 				o.Log.Debug("source %s", src)
 				o.Log.Debug("destination %s", dest)

--- a/pkg/cli/executor.go
+++ b/pkg/cli/executor.go
@@ -261,7 +261,7 @@ func (o *ExecutorSchema) Complete(args []string) {
 
 	// logic to check mode
 	var dest string
-	if strings.Contains(args[0], ociProtocol) || strings.Contains(args[0], fileProtocol) || strings.Contains(args[0], dirProtocol) {
+	if strings.Contains(args[0], ociProtocol) || strings.Contains(args[0], dirProtocol) {
 		o.Opts.Mode = mirrorToDisk
 		dest = workingDir + "/" + strings.Split(args[0], "://")[1]
 		o.Log.Debug("destination %s ", dest)
@@ -299,16 +299,18 @@ func (o *ExecutorSchema) Validate(dest []string) error {
 			return fmt.Errorf("ensure the release field is set and has file:// prefix")
 		}
 		for _, x := range cfg.Mirror.Operators {
-			if !strings.Contains(x.Catalog, fileProtocol) {
+			if !strings.Contains(x.Catalog, dirProtocol) {
 				return fmt.Errorf("ensure the catalog field has a file:// prefix")
 			}
 		}
 		for _, x := range cfg.Mirror.AdditionalImages {
-			if !strings.Contains(x.Name, fileProtocol) {
-				return fmt.Errorf("ensure the additional name field is set and has file:// prefix")
+			if !strings.Contains(x.Name, dirProtocol) {
+				return fmt.Errorf("ensure the additional name field is set and has dir:// prefix")
 			}
 		}
 	}
+	dest[0] = strings.Replace(dest[0], fileProtocol, dirProtocol, 1)
+
 	if strings.Contains(dest[0], ociProtocol) || strings.Contains(dest[0], fileProtocol) || strings.Contains(dest[0], dirProtocol) {
 		return nil
 	} else {

--- a/pkg/operator/collector.go
+++ b/pkg/operator/collector.go
@@ -26,6 +26,10 @@ const (
 	dockerProtocol              string = "docker://"
 	ociProtocol                 string = "oci://"
 	ociProtocolTrimmed          string = "oci:"
+	dirProtocol                 string = "dir://"
+	dirProtocolTrimmed          string = "dir:"
+	fileProtocol                string = "file://"
+	fileProtocolTrimmed         string = "file:"
 	releaseImageDir             string = "release-images"
 	operatorImageDir            string = "operator-images"
 	releaseImageExtractDir      string = "hold-release"
@@ -108,6 +112,12 @@ func (o *Collector) OperatorImageCollector(ctx context.Context) ([]v1alpha3.Copy
 				}
 				src := dockerProtocol + op.Catalog
 				dest := ociProtocolTrimmed + dir
+				// transport := strings.Split(o.Opts.Destination, "://")[0] + ":"
+				// // copy only handles dir: or docker: not file:
+				// if transport == fileProtocolTrimmed {
+				// 	transport = dirProtocolTrimmed
+				// }
+				// dest := transport + dir
 				err = o.Mirror.Run(ctx, src, dest, "copy", &o.Opts, *writer)
 				writer.Flush()
 				if err != nil {

--- a/pkg/operator/collector.go
+++ b/pkg/operator/collector.go
@@ -28,8 +28,6 @@ const (
 	ociProtocolTrimmed          string = "oci:"
 	dirProtocol                 string = "dir://"
 	dirProtocolTrimmed          string = "dir:"
-	fileProtocol                string = "file://"
-	fileProtocolTrimmed         string = "file:"
 	releaseImageDir             string = "release-images"
 	operatorImageDir            string = "operator-images"
 	releaseImageExtractDir      string = "hold-release"

--- a/pkg/operator/collector.go
+++ b/pkg/operator/collector.go
@@ -112,12 +112,6 @@ func (o *Collector) OperatorImageCollector(ctx context.Context) ([]v1alpha3.Copy
 				}
 				src := dockerProtocol + op.Catalog
 				dest := ociProtocolTrimmed + dir
-				// transport := strings.Split(o.Opts.Destination, "://")[0] + ":"
-				// // copy only handles dir: or docker: not file:
-				// if transport == fileProtocolTrimmed {
-				// 	transport = dirProtocolTrimmed
-				// }
-				// dest := transport + dir
 				err = o.Mirror.Run(ctx, src, dest, "copy", &o.Opts, *writer)
 				writer.Flush()
 				if err != nil {
@@ -281,7 +275,7 @@ func batchWorkerConverter(log clog.PluggableLoggerInterface, dir string, images 
 					s := fmt.Sprintf("%d", timestamp)
 					img.Name = fmt.Sprintf("%x", sha256.Sum256([]byte(s)))[:6]
 				}
-				dest := ociProtocolTrimmed + strings.Join([]string{dir, bundle, irs.Namespace, img.Name}, "/")
+				dest := dirProtocolTrimmed + strings.Join([]string{dir, bundle, irs.Namespace, img.Name}, "/")
 				log.Debug("source %s ", img.Image)
 				log.Debug("destination %s ", dest)
 				result = append(result, v1alpha3.CopyImageSchema{Source: src, Destination: dest})

--- a/pkg/release/collector.go
+++ b/pkg/release/collector.go
@@ -24,8 +24,10 @@ const (
 	dockerProtocol              string = "docker://"
 	ociProtocol                 string = "oci://"
 	ociProtocolTrimmed          string = "oci:"
-	fileProtocol                string = "dir://"
-	fileProtocolTrimmed         string = "dir:"
+	dirProtocol                 string = "dir://"
+	dirProtocolTrimmed          string = "dir:"
+	fileProtocol                string = "file://"
+	fileProtocolTrimmed         string = "file:"
 	releaseImageDir             string = "release-images"
 	releaseIndex                string = "release-index"
 	operatorImageDir            string = "operator-images"
@@ -185,7 +187,7 @@ func (o *Collector) ReleaseImageCollector(ctx context.Context) ([]v1alpha3.CopyI
 				component := strings.Split(filepath.Dir(path), "/")
 				img := findRelatedImage(component[len(component)-1], allRelatedImages)
 				if len(img) > 0 {
-					src := fileProtocolTrimmed + filepath.Dir(path)
+					src := dirProtocolTrimmed + filepath.Dir(path)
 					dest := o.Opts.Destination + "/" + img
 					allImages = append(allImages, v1alpha3.CopyImageSchema{Source: src, Destination: dest})
 				} else {
@@ -208,7 +210,7 @@ func batcWorkerConverter(log clog.PluggableLoggerInterface, dir string, images [
 	var result []v1alpha3.CopyImageSchema
 	for _, img := range images {
 		src := dockerProtocol + img.Image
-		dest := fileProtocolTrimmed + strings.Join([]string{dir, "images", img.Name}, "/")
+		dest := dirProtocolTrimmed + strings.Join([]string{dir, "images", img.Name}, "/")
 		// do a lookup on dist first
 		if _, err := os.Stat(dir + "/images/" + img.Name); errors.Is(err, os.ErrNotExist) {
 			err := os.MkdirAll(dir+"/images/"+img.Name, 0750)

--- a/pkg/release/collector.go
+++ b/pkg/release/collector.go
@@ -26,8 +26,6 @@ const (
 	ociProtocolTrimmed          string = "oci:"
 	dirProtocol                 string = "dir://"
 	dirProtocolTrimmed          string = "dir:"
-	fileProtocol                string = "file://"
-	fileProtocolTrimmed         string = "file:"
 	releaseImageDir             string = "release-images"
 	releaseIndex                string = "release-index"
 	operatorImageDir            string = "operator-images"


### PR DESCRIPTION
AdditionalImages handled.
Releases remains as is (already uses dir:)
Operators : just related images switch to dir: while catalogs remain copied to oci transport.